### PR TITLE
#2742

### DIFF
--- a/src/classes/TDTM_ObjectDataGateway.cls
+++ b/src/classes/TDTM_ObjectDataGateway.cls
@@ -71,7 +71,7 @@ public without sharing class TDTM_ObjectDataGateway implements TDTM_iTableDataGa
         for (Trigger_Handler__c th : listTH) {
             Set<String> excludedUserNames = (th.Usernames_to_Exclude__c != null ?
                     new Set<String>(th.Usernames_to_Exclude__c.toLowerCase().split(';')) : new Set<String>());
-            if (th.Object__c == objectName && th.Trigger_Action__c.contains(strAction) && th.Active__c == true
+            if (th.Object__c == objectName && th.Trigger_Action__c != null && th.Trigger_Action__c.contains(strAction) && th.Active__c == true
                     && !excludedUserNames.contains(currUserName.toLowerCase())) {
                 listClasses.add(th);
             }


### PR DESCRIPTION
Updated TDTM_ObjectDataGateway class method (getClassesToCallForObject()) to fix null pointer error in case trigger action is null.

# Critical Changes

# Changes
Added and extra check (th.Trigger_Action__c != null) to make sure Trigger Action is not null and in case it is null we never call that particular class (as user never specified when to call it).

# Issues Closed
#2742

# New Metadata

# Deleted Metadata
